### PR TITLE
Highlight CTE aliases as variable instead of type

### DIFF
--- a/languages/sql/highlights.scm
+++ b/languages/sql/highlights.scm
@@ -1,7 +1,7 @@
 (identifier) @variable
 
 (object_reference (identifier) @type)
-(cte (identifier) @type)
+(cte (identifier) @variable)
 (relation (identifier) @type)
 
 (invocation


### PR DESCRIPTION
## Problem

CTE (Common Table Expression) names in SQL are currently highlighted as `@type` (line 4 of `highlights.scm`):

```scheme
(cte (identifier) @type)
```

This causes CTE aliases (e.g. `my_cte` in `WITH my_cte AS (...)`) to be coloured the same as actual type references like table names and data types. CTE names are **aliases**, not types — they should be visually distinct.

## Fix

Change the capture from `@type` to `@variable`, which is consistent with how `term alias` is already handled on line 27:

```scheme
(term
  alias: (identifier) @variable)
```

Both CTE names and column/expression aliases serve the same semantic role (user-defined aliases), so they should share the same highlight group.

## Before / After

| Before | After |
|--------|-------|
| CTE aliases highlighted as `@type` (same color as table references) | CTE aliases highlighted as `@variable` (same as other aliases) |
