### PR TITLE
Replace highlight captures that don't work in Zed

### DIFF
--- a/languages/sql/highlights.scm
+++ b/languages/sql/highlights.scm
@@ -19,13 +19,13 @@
 ] @function.call
 
 (field
-  name: (identifier) @field)
+  name: (identifier) @property)
 
 (column_definition
-  name: (identifier) @field)
+  name: (identifier) @property)
 
 (column
-  name: (identifier) @field)
+  name: (identifier) @property)
 
 (term
   alias: (identifier) @variable)
@@ -40,10 +40,10 @@
 (marginalia) @comment
 
 ((literal) @number
-   (#match? @number "^[-+]?%d+$"))
+   (#match? @number "^[-+]?\\d+$"))
 
-((literal) @float
-  (#match? @float "^[-+]?%d*\.%d*$"))
+((literal) @number
+  (#match? @number "^[-+]?\\d*\\.\\d*$"))
 
 (parameter) @parameter
 


### PR DESCRIPTION
## Problem

`languages/sql/highlights.scm` contains patterns that appear to have been carried over from nvim-treesitter and do not work in Zed:

1. The `#match?` predicates for numeric literals use Lua-style character classes (`%d`), which Zed's (Rust) regex engine never matches. As a result, all numeric literals fall through to the earlier `(literal) @string` capture and are highlighted as strings.
2. `@float` is not a syntax style that exists in Zed themes, so even if the predicate matched, float literals would be unstyled.
3. `@field` is not a capture that maps to any Zed theme style either, so Zed silently discards it and column names fall back to the earlier `(identifier) @variable` capture instead of being styled as properties.

Partially addresses the "inconsistent highlighting" reports in #37 (string-colored numbers).

## Changes

- Replace `%d` with `\d` in the `#match?` predicates
- Replace `@float` with `@number` (Zed has no `float` style)
- Replace `@field` with `@property` (Zed has no `field` style)

## Before / After

| | Before | After |
|---|---|---|
| Numeric literals (`100.25`, `1.08`, `5`) | string color | number color |
| One Dark | <img width="882" height="866" alt="024" src="https://github.com/user-attachments/assets/cdfb0bda-e8cf-412b-8e5b-28f86113e9c2" /> | <img width="882" height="866" alt="025" src="https://github.com/user-attachments/assets/053f59f3-8db3-4a64-94b7-61b298dad870" /> |
| vscode-dark-polished | <img width="882" height="865" alt="023" src="https://github.com/user-attachments/assets/425acd44-5565-44f2-997c-5763ecbc0d54" /> |  <img width="882" height="865" alt="022" src="https://github.com/user-attachments/assets/2be068bc-bf19-4e00-87b5-6adf87fdb21e" /> |

`@field` → `@property` has no visual effect in themes where `variable` and `property` share a color (e.g. VS Code Dark Modern derivatives), but it makes column names use the intended `property` style instead of falling back to `@variable` via Zed silently discarding the unknown `@field` capture.

## Not addressed (grammar-level, out of scope)

These remain unhighlighted because tree-sitter-sql cannot parse them, which a query-only change cannot fix:

- `SAVEPOINT` statements
- Dollar-quoted strings (`$$ ... $$`), e.g. plpgsql function bodies
- String literals following `INTERVAL`